### PR TITLE
docs: llms.txt + README for AI/machine discovery of EBDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Jeder EBD ist in je bis zu 4 verschiedenen Dateiformaten verfügbar:
 - [DOT](https://graphviz.org/docs/layouts/dot/) (das Format hinter GraphViz, falls das Diagramm nicht zu komplex ist)
 - SVG
 
+## Maschinelle & KI-Zugänglichkeit
+
+Damit KI-Assistenten (z. B. Claude, GitHub Copilot, opencode) und Programme die EBDs finden und lesen können, ohne das Repository zu durchsuchen, werden automatisch Discovery-Dateien erzeugt:
+
+- [`llms.txt`](llms.txt) — Kurzanleitung für KI-Assistenten (Roh-URL-Vertrag, Discovery-Dateien, Beispiele).
+- `format_versions.json` (Repo-Wurzel) — alle Formatversionen inkl. `valid_from` und `latest`.
+- `<FV>/index.json` — Katalog je Formatversion (`ebd_code`, `ebd_name`, `chapter`, `section`, `role`, `pruefidentifikatoren`).
+- `<FV>/pruefi_to_key.json` — Prüfidentifikator → EBD-Kennung (der wichtigste Lookup, da Prüfidentifikatoren direkt aus AHBs/EDIFACT zitiert werden).
+- `<FV>/ebd.schema.json` — JSON-Schema der `<EBD>.json`-Dateien.
+
+Einzelne Dateien sind stabil über Roh-URLs abrufbar: `https://raw.githubusercontent.com/Hochfrequenz/machine-readable_entscheidungsbaumdiagramme/main/<FV>/<EBD>.<ext>`.
+
+Diese Dateien sind Nebenprodukte der [EBD Toolchain](https://github.com/Hochfrequenz/ebd_toolchain) und werden bei jedem Lauf neu erzeugt — bitte nicht von Hand pflegen.
+
 ## Motivation
 
 Wir freuen uns über jede durch dieses Repository ersparte Stunde Arbeit, in der wichtige Probleme gelöst werden können anstatt EBDs zu analysieren.

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,9 @@
 ## Aufbau
 
 Die Daten sind nach **Formatversion** (Gültigkeitszeitraum) abgelegt, nicht nach Format-/AHB-Version.
-Beispiel: `FV2504` = gültig ab 2025-04-01. Pro Formatversion existiert ein Verzeichnis `FV<JJMM>/`.
+Beispiel: `FV2504` gilt für Daten ab dem Frühjahr 2025. Der genaue Gültigkeitsbeginn ist **nicht** immer
+der Monatserste (z. B. begann `FV2506` am 2025-06-06); der maßgebliche Wert je Formatversion steht als
+`valid_from` in `format_versions.json`. Pro Formatversion existiert ein Verzeichnis `FV<JJMM>/`.
 
 Jeder EBD ist über seine **EBD-Kennung** identifiziert (z. B. `E_0401`) und in bis zu vier Formaten abgelegt:
 
@@ -28,20 +30,22 @@ mit `<FV>` ∈ den Formatversionen aus `format_versions.json`, `<EBD>` = EBD-Ken
 
 - **`/format_versions.json`** — alle verfügbaren Formatversionen + `valid_from` + `latest`.
   Nimm im Zweifel `latest`, außer der/die Nutzer:in nennt einen Prüfidentifikator/ein Datum, das zu einer älteren FV gehört.
-- **`/<FV>/index.json`** — Katalog je Formatversion: pro EBD `{ ebd_code, ebd_name, chapter, section, role, pruefidentifikatoren }`.
+- **`/<FV>/index.json`** — Katalog je Formatversion: ein **JSON-Array** von Objekten
+  `{ ebd_code, ebd_name, chapter, section, role, pruefidentifikatoren }` (Letzteres eine Liste von Prüfi-Strings).
   Nutze `ebd_name`/`chapter`/`section` für die natürlichsprachliche Suche → `ebd_code`.
 - **`/<FV>/pruefi_to_key.json`** — **Prüfidentifikator → EBD-Kennung**. Der wichtigste Lookup, denn
   Nutzer:innen zitieren Prüfidentifikatoren (z. B. `55002`) direkt aus AHBs/EDIFACT.
 - **`/<FV>/ebd.schema.json`** — JSON-Schema der `<EBD>.json`-Dateien (Knoten, Prüfschritte, Ergebnisse).
 
-Es werden nur erfolgreich verarbeitete EBDs gelistet — was in `index.json`/`pruefi_to_key.json` steht, existiert also auch als Datei.
+Es werden nur erfolgreich verarbeitete EBDs gelistet; für jeden Eintrag existiert die `<EBD>.json`.
+`.puml`/`.dot`/`.svg` können fehlen (z. B. bei tabellenlosen oder nicht plotbaren EBDs).
 
 ## Vorgehen (Beispiele)
 
 **„Zeig mir den Entscheidungsbaum zu Prüfidentifikator 55002" (neueste FV):**
 1. `format_versions.json` → `latest` (z. B. `FV2610`).
 2. `FV2610/pruefi_to_key.json` → `"55002": "E_0xxx"`.
-3. `FV2610/E_0xxx.json` (Struktur) bzw. `.puml` (Graph) über den Roh-URL-Vertrag laden.
+3. `FV2610/E_0xxx.json` (Struktur; `.puml` für den Graphen, falls vorhanden) über den Roh-URL-Vertrag laden.
 
 **„Welcher EBD prüft die Antwort auf eine Lieferantenwechsel-Anmeldung in der GPKE?":**
 1. Formatversion wählen (i. d. R. `latest`).

--- a/llms.txt
+++ b/llms.txt
@@ -7,9 +7,9 @@
 ## Aufbau
 
 Die Daten sind nach **Formatversion** (Gültigkeitszeitraum) abgelegt, nicht nach Format-/AHB-Version.
-Beispiel: `FV2504` gilt für Daten ab dem Frühjahr 2025. Der genaue Gültigkeitsbeginn ist **nicht** immer
-der Monatserste (z. B. begann `FV2506` am 2025-06-06); der maßgebliche Wert je Formatversion steht als
-`valid_from` in `format_versions.json`. Pro Formatversion existiert ein Verzeichnis `FV<JJMM>/`.
+Der Gültigkeitsbeginn ist **nicht** aus dem Label ableitbar und **nicht** immer der Monatserste
+(z. B. gilt `FV2504` laut BDEW ab dem 2025-06-06). Der maßgebliche Wert je Formatversion steht als
+`valid_from` in `format_versions.json` (Quelle: `efoli`). Pro Formatversion existiert ein Verzeichnis `FV<JJMM>/`.
 
 Jeder EBD ist über seine **EBD-Kennung** identifiziert (z. B. `E_0401`) und in bis zu vier Formaten abgelegt:
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,57 @@
+# machine-readable Entscheidungsbaumdiagramme (EBD)
+
+> Entscheidungsbaumdiagramme (EBD) des deutschen Energiemarkts (EDI@Energy: GPKE, GeLi Gas,
+> WiM, …) in maschinenlesbarer Form. Diese Datei erklärt einem KI-Assistenten, wie er einen
+> EBD findet und liest, ohne das Repository zu durchsuchen.
+
+## Aufbau
+
+Die Daten sind nach **Formatversion** (Gültigkeitszeitraum) abgelegt, nicht nach Format-/AHB-Version.
+Beispiel: `FV2504` = gültig ab 2025-04-01. Pro Formatversion existiert ein Verzeichnis `FV<JJMM>/`.
+
+Jeder EBD ist über seine **EBD-Kennung** identifiziert (z. B. `E_0401`) und in bis zu vier Formaten abgelegt:
+
+- `<EBD>.json` — die strukturierten Rohdaten (**hierüber sollte eine KI argumentieren**); JSON-Schema siehe unten
+- `<EBD>.puml` — PlantUML des Entscheidungsbaums (gut für KI lesbar, falls vorhanden)
+- `<EBD>.dot`  — Graphviz/DOT (falls das Diagramm nicht zu komplex ist)
+- `<EBD>.svg`  — gerendertes Diagramm (**nur zur Anzeige für Menschen**)
+
+## Roh-URL-Vertrag (stabil)
+
+```
+https://raw.githubusercontent.com/Hochfrequenz/machine-readable_entscheidungsbaumdiagramme/main/<FV>/<EBD>.<ext>
+```
+mit `<FV>` ∈ den Formatversionen aus `format_versions.json`, `<EBD>` = EBD-Kennung (z. B. `E_0401`),
+`<ext>` ∈ {json, puml, dot, svg}.
+
+## Discovery-Dateien (so findest du das Richtige)
+
+- **`/format_versions.json`** — alle verfügbaren Formatversionen + `valid_from` + `latest`.
+  Nimm im Zweifel `latest`, außer der/die Nutzer:in nennt einen Prüfidentifikator/ein Datum, das zu einer älteren FV gehört.
+- **`/<FV>/index.json`** — Katalog je Formatversion: pro EBD `{ ebd_code, ebd_name, chapter, section, role, pruefidentifikatoren }`.
+  Nutze `ebd_name`/`chapter`/`section` für die natürlichsprachliche Suche → `ebd_code`.
+- **`/<FV>/pruefi_to_key.json`** — **Prüfidentifikator → EBD-Kennung**. Der wichtigste Lookup, denn
+  Nutzer:innen zitieren Prüfidentifikatoren (z. B. `55002`) direkt aus AHBs/EDIFACT.
+- **`/<FV>/ebd.schema.json`** — JSON-Schema der `<EBD>.json`-Dateien (Knoten, Prüfschritte, Ergebnisse).
+
+Es werden nur erfolgreich verarbeitete EBDs gelistet — was in `index.json`/`pruefi_to_key.json` steht, existiert also auch als Datei.
+
+## Vorgehen (Beispiele)
+
+**„Zeig mir den Entscheidungsbaum zu Prüfidentifikator 55002" (neueste FV):**
+1. `format_versions.json` → `latest` (z. B. `FV2610`).
+2. `FV2610/pruefi_to_key.json` → `"55002": "E_0xxx"`.
+3. `FV2610/E_0xxx.json` (Struktur) bzw. `.puml` (Graph) über den Roh-URL-Vertrag laden.
+
+**„Welcher EBD prüft die Antwort auf eine Lieferantenwechsel-Anmeldung in der GPKE?":**
+1. Formatversion wählen (i. d. R. `latest`).
+2. `FV<…>/index.json` laden, gegen `ebd_name`/`chapter`/`section` matchen → `ebd_code`.
+3. `<ebd_code>.json`/`.puml` über den Roh-URL-Vertrag laden.
+
+**Formatversionen vergleichen** („Was hat sich an `E_0401` zwischen `FV2410` und `FV2504` geändert?"):
+Beide `<FV>/E_0401.json` laden und anhand des `ebd.schema.json` semantisch vergleichen.
+
+## Hinweise
+
+- Zum Argumentieren `.json`/`.puml`/`.dot` verwenden, **nicht** `.svg`.
+- Diese Discovery-Dateien werden automatisch erzeugt (siehe README „Unter der Haube"); nicht von Hand pflegen.


### PR DESCRIPTION
**Draft — depends on the discovery files existing.** Those are produced by Hochfrequenz/ebd_toolchain#397 (per-FV `index.json` / `pruefi_to_key.json` / `ebd.schema.json`) and Hochfrequenz/edi_energy_mirror#481 (repo-root `format_versions.json`). Merge/land those first; then this doc's links resolve.

## What
- **`llms.txt`** — a concise guide for AI assistants: the stable raw-URL contract, the discovery files, the format-choice rule (reason over `.json`/`.puml`, `.svg` is for humans), and worked examples (Prüfidentifikator → key → file; natural-language → `index.json` → key → file; cross-FV diff).
- **README** — new "Maschinelle & KI-Zugänglichkeit" section pointing at `llms.txt` and the discovery files.

## Why
Makes the *existing public* EBD data usable by AI with **no service and no auth** — the lightest path we landed on: publish the data's own map (manifest + per-FV index + Prüfi lookup + schema) so any AI that can fetch a URL or read the repo can resolve a question to the right EBD file.

Docs only — no data changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)