### PR TITLE
docs(llms.txt): clarify `latest` may be a not-yet-effective format version

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,11 @@ mit `<FV>` ∈ den Formatversionen aus `format_versions.json`, `<EBD>` = EBD-Ken
 ## Discovery-Dateien (so findest du das Richtige)
 
 - **`/format_versions.json`** — alle verfügbaren Formatversionen + `valid_from` + `latest`.
-  Nimm im Zweifel `latest`, außer der/die Nutzer:in nennt einen Prüfidentifikator/ein Datum, das zu einer älteren FV gehört.
+  Achtung: `latest` ist die **neueste veröffentlichte** Formatversion — die kann **zukunftsdatiert** und
+  damit noch **nicht in Kraft** sein (z. B. eine FV mit `valid_from` in der Zukunft). Für Fragen nach dem
+  **aktuell gültigen** Stand nimm die FV mit dem größten `valid_from`, das **≤ heute** ist; nur wenn der/die
+  Nutzer:in ausdrücklich den neuesten/zukünftigen Stand will, nimm `latest`. Nennt der/die Nutzer:in einen
+  Prüfidentifikator/ein Datum, das zu einer älteren FV gehört, wähle entsprechend diese.
 - **`/<FV>/index.json`** — Katalog je Formatversion: ein **JSON-Array** von Objekten
   `{ ebd_code, ebd_name, chapter, section, role, pruefidentifikatoren }` (Letzteres eine Liste von Prüfi-Strings).
   Nutze `ebd_name`/`chapter`/`section` für die natürlichsprachliche Suche → `ebd_code`.


### PR DESCRIPTION
## Problem
`llms.txt` advises AI consumers: *„Nimm im Zweifel `latest`"*. But `latest` in `format_versions.json` is the newest **published** format version, which can be **future-dated**. Today (`FV2610` = `valid_from 2026-10-01`) `latest` is not yet in force — the currently-valid version is `FV2604` (valid since 2026-04-01). An assistant answering a "current" regulatory question with the `latest` default therefore returns a version that isn't effective yet.

## Fix
Rewrite the `format_versions.json` guidance in `llms.txt`:
- `latest` = newest *published* FV, possibly future-dated / not yet in force.
- For the **currently valid** state, pick the FV with the greatest `valid_from` that is `<= today`.
- Reserve `latest` for explicit newest/future requests.

Docs-only change. No data or code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)