### PR TITLE
docs(llms.txt): fix broken format-version comparison example

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -52,8 +52,10 @@ Es werden nur erfolgreich verarbeitete EBDs gelistet; für jeden Eintrag existie
 2. `FV<…>/index.json` laden, gegen `ebd_name`/`chapter`/`section` matchen → `ebd_code`.
 3. `<ebd_code>.json`/`.puml` über den Roh-URL-Vertrag laden.
 
-**Formatversionen vergleichen** („Was hat sich an `E_0401` zwischen `FV2410` und `FV2504` geändert?"):
-Beide `<FV>/E_0401.json` laden und anhand des `ebd.schema.json` semantisch vergleichen.
+**Formatversionen vergleichen** („Was hat sich an `E_0623` zwischen `FV2510` und `FV2610` geändert?"):
+Beide `<FV>/E_0623.json` laden und anhand des `ebd.schema.json` semantisch vergleichen.
+(Wähle für einen solchen Vergleich EBD-Kennungen, die in **beiden** Formatversionen existieren — nicht
+jeder EBD kommt in jeder FV vor.)
 
 ## Hinweise
 


### PR DESCRIPTION
## Problem
The "compare format versions" example in `llms.txt` was factually broken:

> „Was hat sich an `E_0401` zwischen `FV2410` und `FV2504` geändert?"

- `E_0401` **does not exist** in `FV2504` (it only goes up to `FV2410`) — so the described `FV2504/E_0401.json` fetch 404s.
- Neither `FV2410` nor `FV2504` ships an `ebd.schema.json`, yet the example instructs the consumer to compare *„anhand des `ebd.schema.json`"*.

An AI assistant following this example verbatim hits dead ends.

## Fix
Use `E_0623` between `FV2510` and `FV2610` — verified present in both, both with `ebd.schema.json`. Added a note to pick EBD keys that exist in both FVs.

Docs-only change. No data or code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)