### PR TITLE
docs: scope the "auto-generated" claim to files the toolchain actually writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Damit KI-Assistenten (z. B. Claude, GitHub Copilot, opencode) und Programme die 
 
 Einzelne Dateien sind stabil über Roh-URLs abrufbar: `https://raw.githubusercontent.com/Hochfrequenz/machine-readable_entscheidungsbaumdiagramme/main/<FV>/<EBD>.<ext>`.
 
-Diese Dateien sind Nebenprodukte der [EBD Toolchain](https://github.com/Hochfrequenz/ebd_toolchain) und werden bei jedem Lauf neu erzeugt — bitte nicht von Hand pflegen.
+Die pro-Formatversion-Dateien (`<FV>/index.json`, `<FV>/pruefi_to_key.json`, `<FV>/ebd.schema.json`) sind Nebenprodukte der [EBD Toolchain](https://github.com/Hochfrequenz/ebd_toolchain) und werden bei jedem Lauf neu erzeugt — bitte nicht von Hand pflegen. `format_versions.json` (Repo-Wurzel) stammt aus einer separaten Quelle (`efoli`); `llms.txt` wird von Hand gepflegt.
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Jeder EBD ist in je bis zu 4 verschiedenen Dateiformaten verfügbar:
 
 ## Maschinelle & KI-Zugänglichkeit
 
-Damit KI-Assistenten (z. B. Claude, GitHub Copilot, opencode) und Programme die EBDs finden und lesen können, ohne das Repository zu durchsuchen, werden automatisch Discovery-Dateien erzeugt:
+Damit KI-Assistenten (z. B. Claude, GitHub Copilot, opencode) und Programme die EBDs finden und lesen können, ohne das Repository zu durchsuchen, stellen wir Discovery-Dateien bereit (die drei formatversionsspezifischen davon werden automatisch erzeugt, siehe unten):
 
 - [`llms.txt`](llms.txt) — Kurzanleitung für KI-Assistenten (Roh-URL-Vertrag, Discovery-Dateien, Beispiele).
 - `format_versions.json` (Repo-Wurzel) — alle Formatversionen inkl. `valid_from` und `latest`.
@@ -35,7 +35,7 @@ Damit KI-Assistenten (z. B. Claude, GitHub Copilot, opencode) und Programme die 
 
 Einzelne Dateien sind stabil über Roh-URLs abrufbar: `https://raw.githubusercontent.com/Hochfrequenz/machine-readable_entscheidungsbaumdiagramme/main/<FV>/<EBD>.<ext>`.
 
-Die pro-Formatversion-Dateien (`<FV>/index.json`, `<FV>/pruefi_to_key.json`, `<FV>/ebd.schema.json`) sind Nebenprodukte der [EBD Toolchain](https://github.com/Hochfrequenz/ebd_toolchain) und werden bei jedem Lauf neu erzeugt — bitte nicht von Hand pflegen. `format_versions.json` (Repo-Wurzel) stammt aus einer separaten Quelle (`efoli`); `llms.txt` wird von Hand gepflegt.
+Die formatversionsspezifischen Dateien (`<FV>/index.json`, `<FV>/pruefi_to_key.json`, `<FV>/ebd.schema.json`) sind Nebenprodukte der [EBD Toolchain](https://github.com/Hochfrequenz/ebd_toolchain) und werden bei jedem Lauf neu erzeugt — bitte nicht von Hand pflegen. `format_versions.json` (Repo-Wurzel) wird nicht von der Toolchain erzeugt (die Formatversionen inkl. `valid_from` stammen aus `efoli`); `llms.txt` wird von Hand gepflegt.
 
 ## Motivation
 

--- a/llms.txt
+++ b/llms.txt
@@ -58,4 +58,6 @@ Beide `<FV>/E_0401.json` laden und anhand des `ebd.schema.json` semantisch vergl
 ## Hinweise
 
 - Zum Argumentieren `.json`/`.puml`/`.dot` verwenden, **nicht** `.svg`.
-- Diese Discovery-Dateien werden automatisch erzeugt (siehe README „Unter der Haube"); nicht von Hand pflegen.
+- Die pro-Formatversion-Dateien (`index.json`, `pruefi_to_key.json`, `ebd.schema.json`) werden von der
+  EBD Toolchain automatisch erzeugt (siehe README „Unter der Haube"); nicht von Hand pflegen. `format_versions.json`
+  stammt aus einer separaten Quelle (`efoli`), diese `llms.txt` wird von Hand gepflegt.

--- a/llms.txt
+++ b/llms.txt
@@ -58,6 +58,7 @@ Beide `<FV>/E_0401.json` laden und anhand des `ebd.schema.json` semantisch vergl
 ## Hinweise
 
 - Zum Argumentieren `.json`/`.puml`/`.dot` verwenden, **nicht** `.svg`.
-- Die pro-Formatversion-Dateien (`index.json`, `pruefi_to_key.json`, `ebd.schema.json`) werden von der
+- Die formatversionsspezifischen Dateien (`index.json`, `pruefi_to_key.json`, `ebd.schema.json`) werden von der
   EBD Toolchain automatisch erzeugt (siehe README „Unter der Haube"); nicht von Hand pflegen. `format_versions.json`
-  stammt aus einer separaten Quelle (`efoli`), diese `llms.txt` wird von Hand gepflegt.
+  wird nicht von der Toolchain erzeugt (die Formatversionen inkl. `valid_from` stammen aus `efoli`); diese `llms.txt`
+  wird von Hand gepflegt.


### PR DESCRIPTION
## Problem
`llms.txt` and `README.md` both claim, without qualification, that *„diese Discovery-Dateien"* are automatically generated by the EBD Toolchain and must not be hand-maintained.

But the toolchain (`ebd_toolchain/src/ebd_toolchain/main.py`) only emits the **per-format-version** files:
- `<FV>/index.json`
- `<FV>/pruefi_to_key.json`
- `<FV>/ebd.schema.json`

It does **not** produce:
- `format_versions.json` (repo root) — comes from a separate source (`efoli`),
- `llms.txt` itself — hand-maintained.

The blanket claim implies `format_versions.json` / `llms.txt` regenerate on a toolchain run, which they don't.

## Fix
Scope the "auto-generated, don't hand-edit" statement to the three per-FV files in both `llms.txt` and `README.md`, and note the separate origin of `format_versions.json` and `llms.txt`.

Docs-only change. No data or code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)